### PR TITLE
Correct architectures value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=This Library can be used for Recive and Send Signals to Insta Funkbus d
 paragraph=InstaFunkbus Library can be used for Recive and Send Signals to Insta Funkbus devices
 category=Device Control
 url=https://github.com/Thro42/InstaFunkbus
-architectures=avr2
+architectures=*


### PR DESCRIPTION
The previous `architectures` value caused the Arduino IDE to display a warning when the library is compiled:
```
WARNING: library InstaFunkbus claims to run on (avr2) architecture(s) and may be incompatible with your current board which runs on (avr) architecture(s).
```
The previous architectures value caused the library's examples to be placed under the **File > Examples > INCOMPATIBLE** menu.

Since I don't see anything architecture-specific in the code I have changed the `architectures` value to `*`.